### PR TITLE
Fix sablono react missing keys

### DIFF
--- a/src/omchaya/components/app.cljs
+++ b/src/omchaya/components/app.cljs
@@ -16,6 +16,9 @@
 
 (defn app [app owner opts]
   (reify
+    om/IDisplayName
+    (display-name [_]
+      "Omchaya")
     om/IRender
     (render [this]
       (let [selected-channel        (get-in app [:channels (:selected-channel app)])
@@ -62,12 +65,16 @@
                          :content-data (get-in app path)
                          :content-opts {}})))
           (om/build keyq/KeyboardHandler app {:opts {:keymap keymap
-                                                     :error-ch (get-in app [:comms :error])}})
-          (om/build-all audio/player (map (fn [[channel-id channel]]
-                                            {:audio-settings (:audio app)
-                                             :player (:player channel)
-                                             :sfx (:sfx channel)
-                                             :id channel-id}) (:channels app)) {:opts {:comms (:comms app)}})
+                                                     :error-ch (get-in app [:comms :error])}
+                                              :react-key "keyboard-handler"})
+          (map #(om/build audio/player %1 {:opts {:comms (:comms app)}
+                                        :react-key (str "audio-player-" %2)})
+               (map (fn [[channel-id channel]]
+                      {:audio-settings (:audio app)
+                       :player (:player channel)
+                       :sfx (:sfx channel)
+                       :id channel-id}) (:channels app))
+               (range))
           (om/build sidebar/sidebar {:channel selected-channel
                                      :settings (:settings app)
                                      :search-filter (get-in app [:settings :forms :search :value])}
@@ -75,12 +82,18 @@
                             :users (:users app)
                             :current-user-email (:current-user-email app)
                             :selected-channel (:selected-channel app)
-                            :channels (:channels app)}})
+                            :channels (:channels app)}
+                     :react-key "sidebar"})
           (om/build main-area/main-area {:channel selected-channel
-                                         :search-filter (get-in app [:settings :forms :search :value])} {:opts {:comms (:comms opts)
-                                                                 :users (:users app)
-                                                                 :current-user-email (:current-user-email app)
-                                                                 :input-focused? (get-in app [:settings :forms :user-message :focused])
-                                                                 :input-value (get-in app [:settings :forms :user-message :value])}})
-          (om/build navbar/navbar (select-keys app [:channels :settings]) {:opts {:comms (:comms opts)}})
+                                         :search-filter (get-in app [:settings :forms :search :value])}
+                    {:opts {:comms (:comms opts)
+                            :users (:users app)
+                            :current-user-email (:current-user-email app)
+                            :input-focused? (get-in app [:settings :forms :user-message :focused])
+                            :input-value (get-in app [:settings :forms :user-message :value])}
+                     :react-key "main-area"})
+          (om/build navbar/navbar
+                    (select-keys app [:channels :settings])
+                    {:opts {:comms (:comms opts)}
+                     :react-key "navbar"})
           [:div#at-view.at-view [:ul#at-view-ul]]])))))

--- a/src/omchaya/components/audio_player.cljs
+++ b/src/omchaya/components/audio_player.cljs
@@ -5,13 +5,18 @@
 
 (defn player [audio-data owner opts]
   (reify
+    om/IDisplayName
+    (display-name [_]
+      "AudioPlayer")
     om/IRender
     (render [this]
       (let [{:keys [sfx player audio-settings id]} audio-data
             audio-source (:source-url player)
             comm (get-in opts [:comms :controls])]
         (html/html
-         [:div {:style #js {:display "none"}}
+         [:div {:react-key id
+                :key id
+                :style #js {:display "none"}}
           [:audio.audio-player
            (merge {:src audio-source
                    :key (str "audio-" id)

--- a/src/omchaya/components/key_queue.cljs
+++ b/src/omchaya/components/key_queue.cljs
@@ -101,8 +101,11 @@
 (defn KeyboardHandler [app owner {:keys [keymap error-ch]}]
   (let [ch (async/chan)]
     (reify
+      om/IDisplayName
+      (display-name [_]
+        "KeyboardHandler")
       om/IDidMount
-      (did-mount [_ _]
+      (did-mount [_]
         (async/tap key-mult ch)
         (async/go-loop [waiting-keys []
                         t-chan nil]

--- a/src/omchaya/components/main_area.cljs
+++ b/src/omchaya/components/main_area.cljs
@@ -23,17 +23,21 @@
 
 (defn activity-entry [current-user-email users settings author activity]
   (list
-   [:div.activity {:id (str "activity-" (:id activity))
-                   :class (when (= current-user-email (:email author)) "current_user")
-                   :key (:created_at activity)}
-    [:span.posted_at (str (dt/time-ago (:created_at activity)) " ago")]
+   [:div.activity {:key (str "activity-" (:id activity))
+                   :id (str "activity-" (:id activity))
+                   :class (when (= current-user-email (:email author)) "current_user")}
+    [:span.posted_at {:key "posted-at"} (str (dt/time-ago (:created_at activity)) " ago")]
     (utils/gravatar-for (:email author))
-    [:div.readable
-     [:span.user (or (:full-name author)
-                     (:email author))]
-     [:span.content (activity-content current-user-email users settings author activity)]]
+    [:div.readable {:key "readable"}
+     [:span.user {:key "user"}
+      (or (:full-name author)
+          (:email author))]
+     [:span.content
+      {:key "content"}
+      (activity-content current-user-email users settings author activity)]]
     (map (fn [media]
            [:div.media-entry
+            {:key "media-entry"}
             media])
          (remove string? (-> (string/split (:content activity) delimiter-re)
                              plugins/image-embed
@@ -42,16 +46,19 @@
 
 
 (defn chatbox [comm opts]
-  [:div.chatbox [:textarea.chat-input
+  [:div.chatbox {:key "chatbox"}
+   [:textarea.chat-input
                  (merge
-                  {:on-focus #(put! comm [:user-message-focused])
+                  {:key "textarea"
+                   :on-focus #(put! comm [:user-message-focused])
                    :on-blur #(put! comm [:user-message-blurred])
                    :on-key-up #(if (= (.. % -which) 13)
                                  (put! comm [:user-message-submitted])
                                  (put! comm [:user-message-updated (.. % -target -value)]))}
                   (when-not (:input-focused? opts)
                     {:value (:input-value opts)}))]
-   [:button.post {:on-click #(put! comm [:user-message-submitted])} "Post"]])
+   [:button.post {:key "button"
+                  :on-click #(put! comm [:user-message-submitted])} "Post"]])
 
 (defn activities-list [filtered-activities opts]
   (map #(let [author (get-in opts [:users (:author %)])]
@@ -64,6 +71,9 @@
 
 (defn main-area [{:keys [channel search-filter]} owner opts]
   (reify
+    om/IDisplayName
+    (display-name [_]
+      "MainArea")
     om/IRender
     (render [this]
       (html/html
@@ -75,24 +85,30 @@
                                    activities)]
          [:article.main-area
           [:header.header
-           [:a.nav-toggle.button.left {:href "#"
-                                       :on-click #(put! comm [:left-sidebar-toggled])} [:i.icon-comments]]
-           [:a.sidebar-toggle.button.right {:href "#"
-                                            :on-click #(put! comm [:right-sidebar-toggled])} [:i.icon-reorder]]
+           {:key "header"}
+           [:a.nav-toggle.button.left {:key "left"
+                                       :href "#"
+                                       :on-click #(put! comm [:left-sidebar-toggled])} [:i.icon-comments {:key "i"}]]
+           [:a.sidebar-toggle.button.right {:key "right"
+                                            :href "#"
+                                            :on-click #(put! comm [:right-sidebar-toggled])} [:i.icon-reorder {:key "i"}]]
            [:a.logo
-            {:href "#/"
+            {:key "logo"
+             :href "#/"
              :on-click (constantly false)}
             [:img
-             {:src "/assets/images/logo.png",
+             {:key "logo-img"
+              :src "/assets/images/logo.png",
               :alt "Omchaya"
               :title "Omchaya - A Kandan Client"}]]]
-          [:div#channels
-           [:div.channels-pane {:id (str "channels-" (:id channel))
+          [:div#channels {:key "channels"}
+           [:div.channels-pane {:key (str "channels-" (:id channel))
+                                :id (str "channels-" (:id channel))
                                 :class (when (:selected channel) "active")}
-            [:div.paginated-activities
+            [:div.paginated-activities {:key "paginated-actvitied"}
              (when (:loading-more-messages channel)
-               [:div.pagination
-                [:i.icon-spinner.icon-spin.icon-2x]
+               [:div.pagination {:key "pagination"}
+                [:i.icon-spinner.icon-spin.icon-2x {:key "i"}]
                 "Loading previous messages"])
              (activities-list filtered-activities opts)]
             (chatbox comm opts)]]])))))

--- a/src/omchaya/components/navbar.cljs
+++ b/src/omchaya/components/navbar.cljs
@@ -11,37 +11,49 @@
                     :on-click #(put! comm [:tab-selected id])
                     :class (str (utils/safe-sel (:id channel)) (when (:selected channel) " active"))}
      [:a.show_channel
-      {:on-click (comp (constantly false)
+      {:key "a"
+       :on-click (comp (constantly false)
                        #(put! comm [:tab-selected id]))}
       (:title channel)
       (when (:loading channel)
-        [:i.icon-spinner.icon-spin])]]))
+        [:i.icon-spinner.icon-spin {:key "i"}])]]))
 
 (defn navbar [data owner opts]
   (reify
+    om/IDisplayName
+    (display-name [_]
+      "Navbar")
     om/IRender
     (render [this]
       (html/html
        (let [comm (get-in opts [:comms :controls])
              settings (:settings data)]
-         [:nav.nav {:class (when (get-in settings [:forms :search :focused]) "search-focus")}
+         [:nav.nav {:key "nav"
+                    :class (when (get-in settings [:forms :search :focused]) "search-focus")}
           [:form.search
-           {:action "/search"
+           {:key "form"
+            :action "/search"
             :method "get"
             :on-submit (constantly false)}
-           [:input.query {:name "query"
+           [:input.query {:key "query"
+                          :name "query"
                           :type "text"
                           :on-focus  #(put! comm [:search-form-focused])
                           :on-blur   #(put! comm [:search-form-blurred])
                           :on-key-up #(put! comm [:search-form-updated (.. % -target -value)])}]
-           [:input.submit {:value "Search"
+           [:input.submit {:key "search"
+                           :value "Search"
                            :type "submit"}]]
           [:ul#channel_nav
+           {:key "channel-nav"}
            (map (partial tab comm) (sort-by :order (vals (:channels data))))
            [:li {:key "new-tab"
                  :on-click #(put! comm [:create-channel-menu-opened])}
             [:a#create_channel
-             {:href "#"
+             {:key "create-channel"
+              :href "#"
               :on-click (comp (constantly false)
                               #(put! comm [:create-channel-menu-opened]))}
-             [:strong " + "]]]]])))))
+             [:strong
+              {:key "strong"}
+              " + "]]]]])))))

--- a/src/omchaya/core.cljs
+++ b/src/omchaya/core.cljs
@@ -52,7 +52,8 @@
      app/app
      state
      {:target target
-      :opts {:comms comms}})
+      :opts {:comms comms}
+      :react-key "omchaya-app"})
     (go (while true
           (alt!
            (:controls comms) ([v]

--- a/src/omchaya/plugins.cljs
+++ b/src/omchaya/plugins.cljs
@@ -3,7 +3,7 @@
             [omchaya.emoticons :as emoticons]))
 
 (defn mention [name]
-  [:span [:span.mention name] " "])
+  [:span {:key "mention"} [:span.mention {:key "mention"} name] " "])
 
 (defn mentions [activity-pieces current-user-email users settings author]
   (map (fn [piece]
@@ -15,7 +15,8 @@
        activity-pieces))
 
 (defn emoticon [emoji]
-  [:img.emoticon-embed.small {:src   (:src emoji)
+  [:img.emoticon-embed.small {:key "emoticon"
+                              :src   (:src emoji)
                               :class (:css emoji)
                               :title (:title emoji)}])
 
@@ -32,7 +33,8 @@
   (let [helper (fn [piece]
                  (if-let [link (and (string? piece)
                                     (re-find #"https?://.*" piece))]
-                   [:a.href {:target "_blank"
+                   [:a.href {:key "href"
+                             :target "_blank"
                              :href link} link]
                    piece))]
     (map helper activity-pieces)))
@@ -42,10 +44,11 @@
         max-preview-lines  4
         original           (string/join " " activity-pieces)]
     (if (re-find #"\n.*\n" original)
-      [[:pre.pastie
-        [:a.pastie-link {:href "#"
+      [[:pre.pastie {:key "pastie"}
+        [:a.pastie-link {:key "href"
+                         :href "#"
                          :on-click (constantly false)} "View pastie"]
-        [:br]
+        [:br {:key "br"}]
         (let [preview (as-> original preview
                             (if (> (count (string/split #"\n" preview)) max-preview-lines)
                               (string/join "\n" (take max-preview-lines (string/split #"\n" preview)))
@@ -66,9 +69,10 @@
   ;; Should actually insert a audio player component
   (let [[command url & rest] activity-pieces]
     (if (= command "/play")
-      (concat [[:strong
-                [:a.audio-play "Playing "
-                 [:a {:target "_blank"
+      (concat [[:strong {:key "strong"}
+                [:a.audio-play "Playing " {:key "playing"}
+                 [:a {:key "a"
+                      :target "_blank"
                       :href url} url]]]] rest)
       activity-pieces)))
 
@@ -77,7 +81,8 @@
          (if-let [[_ pre r g b post] (re-find #"(.*)rgb\((\d{1,3}),(\d{1,3}),(\d{1,3})\)(.*)" piece)]
            (list pre
                  [:span.color-preview
-                  {:style #js {:background-color (str "rgb(" r "," g "," b ")")}}]
+                  {:key "color-preview"
+                   :style #js {:background-color (str "rgb(" r "," g "," b ")")}}]
                  post)
            piece)) activity-pieces))
 
@@ -86,43 +91,48 @@
          (if-let [[_ pre hex post] (re-find #"(.*)#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})(.*)" piece)]
            (list pre
                  [:span.color-preview
-                  {:style #js {:background-color (str "#" hex)}}]
+                  {:key "color-preview"
+                   :style #js {:background-color (str "#" hex)}}]
                  post)
            piece)) activity-pieces))
 
 (defn image-embed [activity-pieces]
   (map (fn [piece]
          (if (re-find #"http.*\.(jpg|jpeg|gif|png)" piece)
-           [:div.image-preview
-            [:a {:target "_blank"
+           [:div.image-preview {:key "preview"}
+            [:a {:key "href"
+                 :target "_blank"
                  :href piece}
-             [:img.image-embed {:src piece}]]
-            [:div.name piece]]
+             [:img.image-embed {:key piece
+                                :src piece}]]
+            [:div.name {:key "name"} piece]]
            piece)) activity-pieces))
 
 (defn youtube-embed [activity-pieces]
   (map (fn [piece]
          (if-let [[_ video-id] (and (re-find #"https?.+www.youtube.com.+watch" piece)
                                     (re-find #"\Wv=([\w|\-]*)" piece))]
-           [:div.youtube-preview
-            [:iframe {:width "560"
+           [:div.youtube-preview {:key "youtube"}
+            [:iframe {:key "iframe"
+                      :width "560"
                       :height "315"
                       :src (str "http://www.youtube.com/embed/" video-id)
                       :frameBorder 0
                       :allowFullScreen true}]
-            [:div.name piece]]
+            [:div.name {:key "name"} piece]]
            piece)) activity-pieces))
 
 (defn vimeo-embed [activity-pieces]
   (map (fn [piece]
          (if-let [[_ video-id] (re-find #"^https?://vimeo.com/(\d+)" piece)]
-           [:div.vimeo-preview
-            [:iframe {:width "500"
+           [:div.vimeo-preview {:key "vimeo"}
+            [:iframe {:key "iframe"
+                      :width "500"
                       :height "281"
                       :src (str "http://player.vimeo.com/video/" video-id)
                       :frameBorder 0
                       :webkitAllowFullScreen true
                       :mozAllowFullScreen true
                       :allowFullScreen true}]
-            [:div.name piece]]
+            [:div.name {:key "name"} piece]]
            piece)) activity-pieces))

--- a/src/omchaya/utils.cljs
+++ b/src/omchaya/utils.cljs
@@ -52,10 +52,10 @@
         hash (crypt/byteArrayToHex (.digest container))]
     (str "http://gravatar.com/avatar/" hash "?s=30&d=identicon")))
 
-(defn gravatar-for [email]
+(defn gravatar-for [email & [optional-uid]]
   [:img.avatar
-   {:src
-    (email->gravatar-url email)}])
+   {:key (str email optional-uid)
+    :src (email->gravatar-url email)}])
 
 (defn set-window-href! [path]
   (js/window.history.pushState #js {}, "", path))


### PR DESCRIPTION
Big speedups from helping React, implements protocols for React Devtools to work nicely with Omchaya. Was _extremely_ helpful for finding which elements didn't have `:key` set properly.

Blocked for merge to master on: https://github.com/r0man/sablono/pull/17
Blocked for merge to master on https://github.com/swannodette/om/commit/62bec9949893748dc2811377345228ec56a774dd until Om >= 0.5.0 is released with IDisplayName support

Blocked for React Devtools until this pr https://github.com/facebook/react-devtools/commit/337c51bd9e03eadfaedbe5ab3c60725503d53286 is released in an extension >= 0.8.0
